### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
     "numexpr>=2.8.3",
 ]
 
+[tool.setuptools.packages.find]
+where = ["autoXRD"]
+
 [project.urls]
 Homepage = "https://github.com/njszym/XRD-AutoAnalyzer"
-
-[tool.setuptools]
-packages = ["autoXRD"]


### PR DESCRIPTION
It seems like I was unable to import some modules. 
```
ImportError                               Traceback (most recent call last)
Cell In[5], line 2
      1 import wandb
----> 2 from autoXRD import cnn, spectrum_generation, solid_solns, tabulate_cifs
      3 import numpy as np
      4 import os

ImportError: cannot import name 'cnn' from 'autoXRD' (/opt/conda/lib/python3.10/site-packages/autoXRD/__init__.py)
```

I think this update to the toml file might make it. 

