### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["autoXRD"]
+where = ["."]
 
 [project.urls]
 Homepage = "https://github.com/njszym/XRD-AutoAnalyzer"


### PR DESCRIPTION
There seems to be still an issue when trying to import autoXRD with the current `pyproject.toml`. This seems to fix it in my fork. 