### PR TITLE
Set `scikit-image` lower pin to support numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "numpy",
     "pymatgen",
     "scipy",
-    "scikit-image",
+    "scikit-image>=0.23.1",
     "tensorflow>=2.16",
     "pyxtal",
     "pyts",


### PR DESCRIPTION
`0.23.1` seems to be the first version to support numpy 2 (numpy ABI changed in NP2):
- https://github.com/scikit-image/scikit-image/blob/bf08f8f120d78a2675522f7334c328c3e60c3469/pyproject.toml#L128

Otherwise would get:
```
venv/lib/python3.12/site-packages/skimage/__init__.py:122: in <module>
    from ._shared import geometry
geometry.pyx:1: in init skimage._shared.geometry
    ???
E   ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```